### PR TITLE
Fixed Sample app crash caused by accessing uninitialized object 

### DIFF
--- a/sample/src/main/java/io/samagra/oce_sample/ODKFeatureTesterActivity.kt
+++ b/sample/src/main/java/io/samagra/oce_sample/ODKFeatureTesterActivity.kt
@@ -68,6 +68,9 @@ class ODKFeatureTesterActivity : AppCompatActivity(), View.OnClickListener {
         ODKProvider.init(application)
         odkInteractor = ODKProvider.getOdkInteractor()
         progressBar.visibility = View.VISIBLE
+        downloadFormsButton.isEnabled=false
+        downloadAllFormsButton.isEnabled=false
+        clearAllFormsButton.isEnabled=false
         odkInteractor.setupODK(IOUtils.toString(resources.openRawResource(R.raw.settings)), false, object :
             ODKProcessListener {
             override fun onProcessComplete() {
@@ -75,6 +78,9 @@ class ODKFeatureTesterActivity : AppCompatActivity(), View.OnClickListener {
                 currentProjectProvider.getCurrentProject().name
                 formsDatabaseInteractor = ODKProvider.getFormsDatabaseInteractor()
                 networkInteractor = ODKProvider.getFormsNetworkInteractor()
+                downloadFormsButton.isEnabled=true
+                downloadAllFormsButton.isEnabled=true
+                clearAllFormsButton.isEnabled=true
                 progressBar.visibility = View.INVISIBLE
             }
             override fun onProcessingError(exception: Exception) {


### PR DESCRIPTION
Closes #52 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Built and tested  the app on emulator  and physical device.
#### Why is this the best possible solution? Were any other approaches considered?
while the  `formsDatabaseInteractor`, `networkInteractor`  objects are  being initialized, we use a circular progress  bar to show the loading state of app, in addition to that we can disable the buttons  `downloadFormsButton` , `downloadAllFormsButton` , `clearAllFormsButton` to prevent exception and once the objects are initialized we can enable them. 
 fix ->
 when not Initialized 
```
downloadFormsButton.isEnabled=false
downloadAllFormsButton.isEnabled=false
clearAllFormsButton.isEnabled=false
```
once they are initialized 
 ```
 downloadFormsButton.isEnabled=true
 downloadAllFormsButton.isEnabled=true
 clearAllFormsButton.isEnabled=true
```
 the case when the crash was happening -
 when the user taps on these buttons `downloadFormsButton` , `downloadAllFormsButton` , `clearAllFormsButton` while object is not initialized.
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
 it  will help in  preventing  app crash caused  by  accessing  uninitialized object `formsDatabaseInteractor`, `networkInteractor`
#### Do we need any specific form for testing your changes? If so, please attach one.
No

